### PR TITLE
[Reviewer: Andy] Memcached DNS resolution and connection pooling tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,8 @@ GMOCK_DIR := $(ROOT)/modules/gmock
 TARGET_TEST := fvtest
 
 TARGET_SOURCES_TEST := memcachedstore.cpp \
+                       baseresolver.cpp \
+                       astaire_resolver.cpp \
                        utils.cpp \
                        memcachedstoreview.cpp \
                        memcached_config.cpp \
@@ -92,6 +94,7 @@ LDFLAGS += -lmemcached \
            -lstdc++ \
            -lrt \
            -lcares \
+           -lboost_regex \
            $(shell net-snmp-config --netsnmp-agent-libs)
 
 

--- a/src/processinstance.cpp
+++ b/src/processinstance.cpp
@@ -122,6 +122,11 @@ bool ProcessInstance::wait_for_instance()
   int attempts = 0;
 
   // If the process hasn't come up after 5 seconds, call the whole thing off.
+  //
+  // Sleep a little bit to begin with to allow the instance to come up,
+  // otherwise we are almost guaranteed to wait for at least 1s.
+  usleep(10000);
+
   while ((!connected) && (attempts < 5))
   {
     if (connect(sockfd, res->ai_addr, res->ai_addrlen) == 0)

--- a/src/processinstance.cpp
+++ b/src/processinstance.cpp
@@ -187,6 +187,8 @@ bool AstaireInstance::execute_process()
          "./cluster_settings",
          "--log-level",
          std::to_string(log_level).c_str(),
+         "--bind-addr",
+         _ip.c_str(),
          (char*)NULL);
   perror("execlp");
   return false;

--- a/src/processinstance.cpp
+++ b/src/processinstance.cpp
@@ -83,7 +83,7 @@ bool ProcessInstance::kill_instance()
   if (kill(_pid, SIGTERM) == 0)
   {
     waitpid(_pid, &status, 0);
-    return WIFSIGNALED(status);
+    return (WIFSIGNALED(status) || WIFEXITED(status));
   }
   else
   {
@@ -187,8 +187,6 @@ bool AstaireInstance::execute_process()
          "./cluster_settings",
          "--log-level",
          std::to_string(log_level).c_str(),
-         "--bind-addr",
-         _ip.c_str(),
          (char*)NULL);
   perror("execlp");
   return false;

--- a/src/processinstance.h
+++ b/src/processinstance.h
@@ -69,7 +69,7 @@ public:
 class AstaireInstance : public ProcessInstance
 {
 public:
-  AstaireInstance(int port) : ProcessInstance(port) {};
+  AstaireInstance(const std::string& ip, int port) : ProcessInstance(ip, port) {};
   virtual bool execute_process();
 };
 
@@ -79,7 +79,7 @@ public:
   DnsmasqInstance(std::string ip, int port, std::map<std::string, std::vector<std::string>> a_records) :
     ProcessInstance(ip, port) { write_config(a_records); };
   ~DnsmasqInstance() { std::remove(_cfgfile.c_str()); };
-  
+
   bool execute_process();
 private:
   void write_config(std::map<std::string, std::vector<std::string>> a_records);

--- a/src/processinstance.h
+++ b/src/processinstance.h
@@ -51,6 +51,9 @@ public:
   bool restart_instance();
   bool wait_for_instance();
 
+  std::string ip() const { return _ip; }
+  int port() const { return _port; }
+
 private:
   virtual bool execute_process() = 0;
 

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -910,6 +910,12 @@ TYPED_TEST(MemcachedSolutionFailureTest, AddKillSetSetDataContentionSet)
     EXPECT_EQ(data_out, data_in);
 
     TypeParam::fix_failure(this);
+
+    // Bounce the store to prevent failures in this iteration from affecting
+    // the next one.
+    delete this->_store; this->_store = NULL;
+    this->_store = new TopologyNeutralMemcachedStore("astaire.local",
+                                                     this->_resolver);
   }
 }
 

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -1217,6 +1217,12 @@ TYPED_TEST(MemcachedSolutionThrashTest, ThrashTest)
     threads[i].join();
   }
 
+  // the purpose of this sleep is to allow the connections in the store to
+  // become idle so that we hit the code that cleans them up. This isn't really
+  // testing the API (as we need to know the connection timeout), but at least
+  // we don't place any extra constraints on the API.
+  sleep(61);
+
   for (int i = 0; i < 10; ++i)
   {
     SCOPED_TRACE(keys[i]);

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -94,7 +94,9 @@ public:
   /// previous test, and the new test will assume this.
   virtual void SetUp()
   {
-    _store = new TopologyNeutralMemcachedStore();
+    _dns_client = new DnsCachedResolver("127.0.0.1");
+    _resolver = new AstaireResolver(_dns_client, AF_INET);
+    _store = new TopologyNeutralMemcachedStore("127.0.0.1", _resolver);
 
     // Create a new key for every test (to prevent tests from interacting with
     // each other).
@@ -107,6 +109,8 @@ public:
   virtual void TearDown()
   {
     delete _store; _store = NULL;
+    delete _resolver; _resolver = NULL;
+    delete _dns_client; _dns_client = NULL;
   }
 
   /// Helper method for generating a new unique key in the middle of a test.
@@ -236,6 +240,8 @@ public:
     return _store->delete_data(_table, _key, DUMMY_TRAIL_ID);
   }
 
+  DnsCachedResolver* _dns_client;
+  AstaireResolver* _resolver;
   TopologyNeutralMemcachedStore* _store;
 
   /// Use shared pointers for managing the instances so that the memory gets

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -95,9 +95,9 @@ public:
   /// previous test, and the new test will assume this.
   virtual void SetUp()
   {
-    _dns_client = new DnsCachedResolver("127.0.0.1");
+    _dns_client = new DnsCachedResolver("127.0.0.1", 5353);
     _resolver = new AstaireResolver(_dns_client, AF_INET);
-    _store = new TopologyNeutralMemcachedStore("127.0.0.1", _resolver);
+    _store = new TopologyNeutralMemcachedStore("astaire.local", _resolver);
 
     // Create a new key for every test (to prevent tests from interacting with
     // each other).
@@ -178,7 +178,8 @@ public:
     }
 
     _dnsmasq_instance = std::shared_ptr<DnsmasqInstance>(
-      new DnsmasqInstance("127.0.0.1", 53, {{"astaire.local", hosts}}));
+      new DnsmasqInstance("127.0.0.1", 5353, {{"astaire.local", hosts}}));
+    _dnsmasq_instance->start_instance();
   }
 
   /// Wait for all existing memcached and Astaire instances to come up by
@@ -324,6 +325,7 @@ class SimpleMemcachedSolutionMainlineTest : public BaseMemcachedSolutionTest
   {
     create_and_start_memcached_instances(2);
     create_and_start_astaire_instances(1);
+    create_and_start_dns_for_astaire(1);
 
     BaseMemcachedSolutionTest::SetUpTestCase();
   }
@@ -588,6 +590,7 @@ class SimpleMemcachedSolutionFailureTest : public BaseMemcachedSolutionTest
   {
     create_and_start_memcached_instances(T::num_memcached_instances());
     create_and_start_astaire_instances(T::num_astaire_instances());
+    create_and_start_dns_for_astaire(T::num_astaire_instances());
 
     BaseMemcachedSolutionTest::SetUpTestCase();
   }
@@ -859,6 +862,7 @@ class LargerClustersMemcachedSolutionTest : public BaseMemcachedSolutionTest
   {
     create_and_start_memcached_instances(3);
     create_and_start_astaire_instances(1);
+    create_and_start_dns_for_astaire(1);
 
     BaseMemcachedSolutionTest::SetUpTestCase();
   }

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -234,10 +234,10 @@ public:
   }
 
   /// Helper method for setting data in memcached for a specified key.
-  Store::Status set_data(std::string& key,
-                         std::string& data,
+  Store::Status set_data(const std::string& key,
+                         const std::string& data,
                          uint64_t cas,
-                         int expiry = 5)
+                         int expiry = 60)
   {
     return _store->set_data(_table,
                             key,
@@ -553,6 +553,11 @@ TEST_F(SimpleMemcachedSolutionTest, AddSetCASDeleteDataContentionCASDelete)
   rc = this->set_data(data_in, cas, 0);
   EXPECT_EQ(Store::Status::OK, rc);
 
+  // Check that the data has been deleted.
+  //
+  // We have to sleep a bit here as replications to the non-primary memcacheds
+  // is asynchronous so can race against the GET we are about to perform.
+  usleep(10000);
   rc = this->get_data(data_out, cas);
   EXPECT_EQ(Store::Status::NOT_FOUND, rc);
 }

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -573,6 +573,59 @@ TEST_F(SimpleMemcachedSolutionMainlineTest, AddDeleteSetDataContention)
   EXPECT_EQ(Store::Status::DATA_CONTENTION, rc);
 }
 
+TEST_F(SimpleMemcachedSolutionMainlineTest, ConnectUsingIpAddress)
+{
+  delete _store; _store = NULL;
+  _store = new TopologyNeutralMemcachedStore("127.0.0.1", _resolver);
+
+  uint64_t cas = 0;
+  Store::Status rc;
+  std::string data_in = "SimpleMemcachedSolutionMainlineTest.AddGet";
+  std::string data_out;
+
+  rc = this->set_data(data_in, cas);
+  EXPECT_EQ(Store::Status::OK, rc);
+
+  rc = this->get_data(data_out, cas);
+  EXPECT_EQ(Store::Status::OK, rc);
+  EXPECT_EQ(data_out, data_in);
+
+  data_in = "SimpleMemcachedSolutionMainlineTest.AddGet_1";
+  rc = this->set_data(data_in, cas);
+  EXPECT_EQ(Store::Status::OK, rc);
+
+  rc = this->get_data(data_out, cas);
+  EXPECT_EQ(Store::Status::OK, rc);
+  EXPECT_EQ(data_out, data_in);
+
+  rc = this->delete_data();
+  EXPECT_EQ(Store::Status::OK, rc);
+
+  rc = this->get_data(data_out, cas);
+  EXPECT_EQ(Store::Status::NOT_FOUND, rc);
+}
+
+
+TEST_F(SimpleMemcachedSolutionMainlineTest, BadDomainName)
+{
+  delete _store; _store = NULL;
+  _store = new TopologyNeutralMemcachedStore("bad.domain.name", _resolver);
+
+  uint64_t cas = 0;
+  Store::Status rc;
+  std::string data_in = "SimpleMemcachedSolutionMainlineTest.AddGet";
+  std::string data_out;
+
+  rc = this->set_data(data_in, cas);
+  EXPECT_EQ(Store::Status::ERROR, rc);
+
+  rc = this->get_data(data_out, cas);
+  EXPECT_EQ(Store::Status::ERROR, rc);
+
+  rc = this->delete_data();
+  EXPECT_EQ(Store::Status::ERROR, rc);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 ///
 /// SimpleMemcachedSolutionFailureTest testcases start here.


### PR DESCRIPTION
Andy, please can you review the FV tests for the topology-neutral memcached store. This should match the test plan you've reviewed. 

As discussed, there are still a couple of issues with the tests that I'm tracking down so I may submit a few fixes over the next day or so - hopefully that's not a problem. 

The tests take quite a long time to run, as Astaire takes ~4s to restart. This is because Astaire's LVC and signal waiters each take ~1s to stop. I could compile Astaire with `-DUNIT_TEST` to use shorter timeouts, but I haven't come up with a nice way of plumbing this through yet. 
