### PR TITLE
[No reviewer] Don't readd SAS client module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /build/
 /usr/
 fvtest-snmpd.out
+
+src/127.0.0.1_5353__dnsmasq.cfg
+src/cluster_settings


### PR DESCRIPTION
The sas-client submodule got half re-added by update-cpp-common. This PR removes it again (and I've fixed up the script)
