### PR TITLE
[No reviewer] Add ignore_vbucket to memcached options

### DIFF
--- a/src/processinstance.cpp
+++ b/src/processinstance.cpp
@@ -156,6 +156,8 @@ bool MemcachedInstance::execute_process()
          "127.0.0.1",
          "-p",
          std::to_string(_port).c_str(),
+         "-e",
+         "ignore_vbucket=true",
          (char*)NULL);
   perror("execlp");
   return false;

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -197,7 +197,7 @@ public:
          inst != _memcached_instances.end();
          ++inst)
     {
-      (*inst)->wait_for_instance();
+      success = (*inst)->wait_for_instance();
 
       if (!success)
       {
@@ -209,7 +209,7 @@ public:
          inst != _astaire_instances.end();
          ++inst)
     {
-      (*inst)->wait_for_instance();
+      success = (*inst)->wait_for_instance();
 
       if (!success)
       {
@@ -219,7 +219,7 @@ public:
 
     if (_dnsmasq_instance)
     {
-      _dnsmasq_instance->wait_for_instance();
+      success = _dnsmasq_instance->wait_for_instance();
 
       if (!success)
       {


### PR DESCRIPTION
Pass in ignore_vbucket option to memcached parameters (to match the parameters we use in our deployments)
