### PR TITLE
[No reviewer]Add rapidjson as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "modules/astaire"]
 	path = modules/astaire
 	url = git@github.com:Metaswitch/astaire.git
+[submodule "modules/rapidjson"]
+	path = modules/rapidjson
+	url = git@github.com:miloyip/rapidjson.git

--- a/src/Makefile
+++ b/src/Makefile
@@ -69,7 +69,8 @@ CPPFLAGS += -Wno-write-strings \
             -ggdb3 -std=c++0x
 CPPFLAGS += -I${ROOT}/include \
             -I${ASTAIRE_INCLUDES} \
-            -I${ROOT}/modules/cpp-common/include
+            -I${ROOT}/modules/cpp-common/include \
+            -I${ROOT}/modules/rapidjson/include
 
 # Add cpp-common/src as a VPATH to pull in required production code
 VPATH := ${ROOT}/modules/cpp-common/src ${ROOT}/modules/cpp-common/test_utils


### PR DESCRIPTION
- cpp-common uses rapidjson, and it's now required by this repo
