### PR TITLE
[Reviewer: Seb] Resolve Rogers based changes to the FV tests

### DIFF
--- a/src/processinstance.cpp
+++ b/src/processinstance.cpp
@@ -138,9 +138,9 @@ bool MemcachedInstance::execute_process()
   return false;
 }
 
-bool AstaireInstance::execute_process()
+std::string get_log_level()
 {
-  // Run Astaire at the same log level as the tests by parsing the NOISY=t:?
+  // Work out the log level of the tests by parsing the NOISY=t:?
   // environment variable.
   int log_level = 0;
   char* val = getenv("NOISY");
@@ -157,18 +157,21 @@ bool AstaireInstance::execute_process()
     }
   }
 
-  // Start Astaire. execlp only returns if an error has occurred, in which case
+  return std::to_string(log_level);
+}
+
+bool RogersInstance::execute_process()
+{
+  // Start Rogers. execlp only returns if an error has occurred, in which case
   // return false. This assumes that cluster_settings has been setup.
-  execlp("../modules/astaire/build/bin/astaire",
-         "astaire",
-         "--local-name",
-         "127.0.0.1",
+  execlp("../modules/astaire/build/bin/rogers",
+         "rogers",
          "--bind-addr",
          _ip.c_str(),
          "--cluster-settings-file",
          "./cluster_settings",
          "--log-level",
-         std::to_string(log_level).c_str(),
+         get_log_level().c_str(),
          (char*)NULL);
   perror("execlp");
   return false;

--- a/src/processinstance.h
+++ b/src/processinstance.h
@@ -44,10 +44,10 @@ public:
   virtual bool execute_process();
 };
 
-class AstaireInstance : public ProcessInstance
+class RogersInstance : public ProcessInstance
 {
 public:
-  AstaireInstance(const std::string& ip, int port) : ProcessInstance(ip, port) {};
+  RogersInstance(const std::string& ip, int port) : ProcessInstance(ip, port) {};
   virtual bool execute_process();
 };
 

--- a/src/test_memcachedsolution.cpp
+++ b/src/test_memcachedsolution.cpp
@@ -129,7 +129,7 @@ public:
     cluster_settings.close();
   }
 
-  /// Creates and starts up the specified number of ogers instances. We
+  /// Creates and starts up the specified number of Rogers instances. We
   /// currently only support one Rogers instance (since the port Rogers
   /// listens on is not currently configurable).
   static void create_and_start_rogers_instances(int rogers_instances)


### PR DESCRIPTION
The FV tests are designed to test the proxy function so they should use rogers. This is basically a wholesale change from Astaire to Rogers, with a small amount of code tidy up.