### PR TITLE
Temporarily disable the S4 valgrind tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -232,8 +232,11 @@ vg-check: vg
 
 .PHONY: vg_raw
 vg_raw: build_test | $(TEST_OUT_DIR)
+	@echo "!!"
+	@echo "!! WARNING. S4 tests are currently not run under valgrind."
+	@echo "!!"
 	LD_LIBRARY_PATH=${ASTAIRE_LIBS} valgrind --gen-suppressions=all $(VGFLAGS) \
-	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*' $(EXTRA_TEST_ARGS)
+	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*:*S4*' $(EXTRA_TEST_ARGS)
 
 .PHONY: distclean
 distclean: clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -208,8 +208,11 @@ debug: build_test
 # test failure from Jenkins.
 .PHONY: vg
 vg: build_test | $(TEST_OUT_DIR)
+	@echo "!!"
+	@echo "!! WARNING. S4 tests are currently not run under valgrind."
+	@echo "!!"
 	LD_LIBRARY_PATH=${ASTAIRE_LIBS} valgrind --xml=yes --xml-file=$(VG_XML) $(VGFLAGS) \
-	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*' $(EXTRA_TEST_ARGS) > $(VG_OUT) 2>&1
+	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*:*S4*' $(EXTRA_TEST_ARGS) > $(VG_OUT) 2>&1
 
 # Check whether there were any errors from valgrind. Output to screen any errors found,
 # and details of where to find the full logs.


### PR DESCRIPTION
It turns out that our HTTP server leaks memory when it is terminated, which are messing up the FV test valgrind runs. This disables valgrind for the S4 tests. We decided that was preferable to disabling the S4 tests entirely, as it allows the functional tests to run, and for people to develop new S4 tests. 

Tested by running make vg. Output below. The S4 tests were not run. 

```
Running with random seed: 1519340095
Note: Google Test filter = -*DeathTest*:*S4*
[==========] Running 70 tests from 11 test cases.
[----------] Global test environment set-up.
[----------] 1 test from DNSTest
[ RUN      ] DNSTest.BasicQuery
[       OK ] DNSTest.BasicQuery (580 ms)
[----------] 1 test from DNSTest (595 ms total)

[----------] 19 tests from SNMPTest
[ RUN      ] SNMPTest.ScalarValue
[       OK ] SNMPTest.ScalarValue (191 ms)
[ RUN      ] SNMPTest.TableOrdering
[       OK ] SNMPTest.TableOrdering (336 ms)
[ RUN      ] SNMPTest.LatencyCalculations
[       OK ] SNMPTest.LatencyCalculations (198 ms)
[ RUN      ] SNMPTest.LatencyScopeCalculations
[       OK ] SNMPTest.LatencyScopeCalculations (636 ms)
[ RUN      ] SNMPTest.StringBasedEventStats
[       OK ] SNMPTest.StringBasedEventStats (2394 ms)
[ RUN      ] SNMPTest.CounterTimePeriods
[       OK ] SNMPTest.CounterTimePeriods (552 ms)
[ RUN      ] SNMPTest.IPCountTable
[       OK ] SNMPTest.IPCountTable (100 ms)
[ RUN      ] SNMPTest.SuccessFailCountTable
[       OK ] SNMPTest.SuccessFailCountTable (260 ms)
[ RUN      ] SNMPTest.SingleCountByNodeTypeTable
[       OK ] SNMPTest.SingleCountByNodeTypeTable (716 ms)
[ RUN      ] SNMPTest.SuccessFailCountByRequestTypeTable
[       OK ] SNMPTest.SuccessFailCountByRequestTypeTable (1302 ms)
[ RUN      ] SNMPTest.ContinuousAccumulatorTable
[       OK ] SNMPTest.ContinuousAccumulatorTable (459 ms)
[ RUN      ] SNMPTest.CxCounterTable
[       OK ] SNMPTest.CxCounterTable (787 ms)
[ RUN      ] SNMPTest.IPTimeBasedCounterTableSingleIPZeroCount
[       OK ] SNMPTest.IPTimeBasedCounterTableSingleIPZeroCount (187 ms)
[ RUN      ] SNMPTest.IPTimeBasedCounterTableRefcountIP
[       OK ] SNMPTest.IPTimeBasedCounterTableRefcountIP (61 ms)
[ RUN      ] SNMPTest.IPTimeBasedCounterTableRefcountDeleteIP
[       OK ] SNMPTest.IPTimeBasedCounterTableRefcountDeleteIP (75 ms)
[ RUN      ] SNMPTest.IPTimeBasedCounterTableSingleIP
[       OK ] SNMPTest.IPTimeBasedCounterTableSingleIP (51 ms)
[ RUN      ] SNMPTest.IPTimeBasedCounterTableMultipleIPs
[       OK ] SNMPTest.IPTimeBasedCounterTableMultipleIPs (84 ms)
[ RUN      ] SNMPTest.IPTimeBasedCounterTableRemoveIP
[       OK ] SNMPTest.IPTimeBasedCounterTableRemoveIP (117 ms)
[ RUN      ] SNMPTest.IPTimeBasedCounterTableAddCountsAgeOut
[       OK ] SNMPTest.IPTimeBasedCounterTableAddCountsAgeOut (261 ms)
[----------] 19 tests from SNMPTest (8778 ms total)

[----------] 13 tests from SimpleMemcachedSolutionTest
[ RUN      ] SimpleMemcachedSolutionTest.AddGet
[       OK ] SimpleMemcachedSolutionTest.AddGet (572 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddGetTwoKeys
[       OK ] SimpleMemcachedSolutionTest.AddGetTwoKeys (140 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddGetExpire
[       OK ] SimpleMemcachedSolutionTest.AddGetExpire (2164 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddSetSetDataContentionSet
[       OK ] SimpleMemcachedSolutionTest.AddSetSetDataContentionSet (191 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddSetCASDeleteDataContentionCASDelete
[       OK ] SimpleMemcachedSolutionTest.AddSetCASDeleteDataContentionCASDelete (183 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddAddDataContention
[       OK ] SimpleMemcachedSolutionTest.AddAddDataContention (134 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddDelete
[       OK ] SimpleMemcachedSolutionTest.AddDelete (160 ms)
[ RUN      ] SimpleMemcachedSolutionTest.Delete
[       OK ] SimpleMemcachedSolutionTest.Delete (98 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddDeleteAdd
[       OK ] SimpleMemcachedSolutionTest.AddDeleteAdd (165 ms)
[ RUN      ] SimpleMemcachedSolutionTest.AddDeleteSetDataContention
[       OK ] SimpleMemcachedSolutionTest.AddDeleteSetDataContention (147 ms)
[ RUN      ] SimpleMemcachedSolutionTest.ConnectUsingIpAddress
[       OK ] SimpleMemcachedSolutionTest.ConnectUsingIpAddress (129 ms)
[ RUN      ] SimpleMemcachedSolutionTest.BadDomainName
[       OK ] SimpleMemcachedSolutionTest.BadDomainName (136 ms)
[ RUN      ] SimpleMemcachedSolutionTest.DomainAndPort
[       OK ] SimpleMemcachedSolutionTest.DomainAndPort (154 ms)
[----------] 13 tests from SimpleMemcachedSolutionTest (4382 ms total)

[----------] 6 tests from MemcachedSolutionFailureTest/0, where TypeParam = MemcachedFailsScenario
[ RUN      ] MemcachedSolutionFailureTest/0.KillAddGet
[       OK ] MemcachedSolutionFailureTest/0.KillAddGet (2123 ms)
[ RUN      ] MemcachedSolutionFailureTest/0.AddKillGet
[       OK ] MemcachedSolutionFailureTest/0.AddKillGet (2066 ms)
[ RUN      ] MemcachedSolutionFailureTest/0.AddKillGetExpire
[       OK ] MemcachedSolutionFailureTest/0.AddKillGetExpire (4078 ms)
[ RUN      ] MemcachedSolutionFailureTest/0.AddKillSetSetDataContentionSet
[       OK ] MemcachedSolutionFailureTest/0.AddKillSetSetDataContentionSet (21266 ms)
[ RUN      ] MemcachedSolutionFailureTest/0.AddDeleteKill
[       OK ] MemcachedSolutionFailureTest/0.AddDeleteKill (2067 ms)
[ RUN      ] MemcachedSolutionFailureTest/0.AddKillCASDelete
[       OK ] MemcachedSolutionFailureTest/0.AddKillCASDelete (2106 ms)
[----------] 6 tests from MemcachedSolutionFailureTest/0 (33718 ms total)

[----------] 6 tests from MemcachedSolutionFailureTest/1, where TypeParam = MemcachedRestartsScenario
[ RUN      ] MemcachedSolutionFailureTest/1.KillAddGet
[       OK ] MemcachedSolutionFailureTest/1.KillAddGet (2110 ms)
[ RUN      ] MemcachedSolutionFailureTest/1.AddKillGet
[       OK ] MemcachedSolutionFailureTest/1.AddKillGet (2031 ms)
[ RUN      ] MemcachedSolutionFailureTest/1.AddKillGetExpire
[       OK ] MemcachedSolutionFailureTest/1.AddKillGetExpire (4063 ms)
[ RUN      ] MemcachedSolutionFailureTest/1.AddKillSetSetDataContentionSet
[       OK ] MemcachedSolutionFailureTest/1.AddKillSetSetDataContentionSet (20651 ms)
[ RUN      ] MemcachedSolutionFailureTest/1.AddDeleteKill
[       OK ] MemcachedSolutionFailureTest/1.AddDeleteKill (1967 ms)
[ RUN      ] MemcachedSolutionFailureTest/1.AddKillCASDelete
[       OK ] MemcachedSolutionFailureTest/1.AddKillCASDelete (2089 ms)
[----------] 6 tests from MemcachedSolutionFailureTest/1 (32915 ms total)

[----------] 6 tests from MemcachedSolutionFailureTest/2, where TypeParam = RogersFailsScenario
[ RUN      ] MemcachedSolutionFailureTest/2.KillAddGet
[       OK ] MemcachedSolutionFailureTest/2.KillAddGet (2139 ms)
[ RUN      ] MemcachedSolutionFailureTest/2.AddKillGet
[       OK ] MemcachedSolutionFailureTest/2.AddKillGet (2079 ms)
[ RUN      ] MemcachedSolutionFailureTest/2.AddKillGetExpire
[       OK ] MemcachedSolutionFailureTest/2.AddKillGetExpire (4145 ms)
[ RUN      ] MemcachedSolutionFailureTest/2.AddKillSetSetDataContentionSet
[       OK ] MemcachedSolutionFailureTest/2.AddKillSetSetDataContentionSet (21174 ms)
[ RUN      ] MemcachedSolutionFailureTest/2.AddDeleteKill
[       OK ] MemcachedSolutionFailureTest/2.AddDeleteKill (2083 ms)
[ RUN      ] MemcachedSolutionFailureTest/2.AddKillCASDelete
[       OK ] MemcachedSolutionFailureTest/2.AddKillCASDelete (2116 ms)
[----------] 6 tests from MemcachedSolutionFailureTest/2 (33747 ms total)

[----------] 6 tests from MemcachedSolutionFailureTest/3, where TypeParam = RogersRestartsScenario
[ RUN      ] MemcachedSolutionFailureTest/3.KillAddGet
[       OK ] MemcachedSolutionFailureTest/3.KillAddGet (3177 ms)
[ RUN      ] MemcachedSolutionFailureTest/3.AddKillGet
[       OK ] MemcachedSolutionFailureTest/3.AddKillGet (2021 ms)
[ RUN      ] MemcachedSolutionFailureTest/3.AddKillGetExpire
[       OK ] MemcachedSolutionFailureTest/3.AddKillGetExpire (4052 ms)
[ RUN      ] MemcachedSolutionFailureTest/3.AddKillSetSetDataContentionSet
[       OK ] MemcachedSolutionFailureTest/3.AddKillSetSetDataContentionSet (20668 ms)
[ RUN      ] MemcachedSolutionFailureTest/3.AddDeleteKill
[       OK ] MemcachedSolutionFailureTest/3.AddDeleteKill (2039 ms)
[ RUN      ] MemcachedSolutionFailureTest/3.AddKillCASDelete
[       OK ] MemcachedSolutionFailureTest/3.AddKillCASDelete (2101 ms)
[----------] 6 tests from MemcachedSolutionFailureTest/3 (34065 ms total)

[----------] 6 tests from MemcachedSolutionFailureTest/4, where TypeParam = LoneRogersRestartsScenario
[ RUN      ] MemcachedSolutionFailureTest/4.KillAddGet
[       OK ] MemcachedSolutionFailureTest/4.KillAddGet (2114 ms)
[ RUN      ] MemcachedSolutionFailureTest/4.AddKillGet
[       OK ] MemcachedSolutionFailureTest/4.AddKillGet (2030 ms)
[ RUN      ] MemcachedSolutionFailureTest/4.AddKillGetExpire
[       OK ] MemcachedSolutionFailureTest/4.AddKillGetExpire (4057 ms)
[ RUN      ] MemcachedSolutionFailureTest/4.AddKillSetSetDataContentionSet
[       OK ] MemcachedSolutionFailureTest/4.AddKillSetSetDataContentionSet (20592 ms)
[ RUN      ] MemcachedSolutionFailureTest/4.AddDeleteKill
[       OK ] MemcachedSolutionFailureTest/4.AddDeleteKill (2026 ms)
[ RUN      ] MemcachedSolutionFailureTest/4.AddKillCASDelete
[       OK ] MemcachedSolutionFailureTest/4.AddKillCASDelete (2077 ms)
[----------] 6 tests from MemcachedSolutionFailureTest/4 (32908 ms total)

[----------] 3 tests from LargerClustersMemcachedSolutionTest/0, where TypeParam = LargeClusterMemcachedFails
[ RUN      ] LargerClustersMemcachedSolutionTest/0.AddGet
[       OK ] LargerClustersMemcachedSolutionTest/0.AddGet (125 ms)
[ RUN      ] LargerClustersMemcachedSolutionTest/0.AddKillGet
[       OK ] LargerClustersMemcachedSolutionTest/0.AddKillGet (1968 ms)
[ RUN      ] LargerClustersMemcachedSolutionTest/0.AddKillGetSet
[       OK ] LargerClustersMemcachedSolutionTest/0.AddKillGetSet (2128 ms)
[----------] 3 tests from LargerClustersMemcachedSolutionTest/0 (4228 ms total)

[----------] 3 tests from LargerClustersMemcachedSolutionTest/1, where TypeParam = LargeClusterMemcachedRestarts
[ RUN      ] LargerClustersMemcachedSolutionTest/1.AddGet
[       OK ] LargerClustersMemcachedSolutionTest/1.AddGet (123 ms)
[ RUN      ] LargerClustersMemcachedSolutionTest/1.AddKillGet
[       OK ] LargerClustersMemcachedSolutionTest/1.AddKillGet (1983 ms)
[ RUN      ] LargerClustersMemcachedSolutionTest/1.AddKillGetSet
[       OK ] LargerClustersMemcachedSolutionTest/1.AddKillGetSet (2100 ms)
[----------] 3 tests from LargerClustersMemcachedSolutionTest/1 (4209 ms total)

[----------] 1 test from MemcachedSolutionThrashTest/0, where TypeParam = NoFailuresScenario
[ RUN      ] MemcachedSolutionThrashTest/0.ThrashTest
[       OK ] MemcachedSolutionThrashTest/0.ThrashTest (81323 ms)
[----------] 1 test from MemcachedSolutionThrashTest/0 (81326 ms total)

[----------] Global test environment tear-down
[==========] 70 tests from 11 test cases ran. (290642 ms total)
[  PASSED  ] 70 tests.
```